### PR TITLE
Fix Ether constant magic address

### DIFF
--- a/docs/api_abi-kybernetwork.md
+++ b/docs/api_abi-kybernetwork.md
@@ -339,7 +339,7 @@ Web3 Example:
 // should always do your own testing. If you have questions, visit our
 // https://t.me/KyberDeveloper.
 
-const src = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"; // ETH
+const src = "0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"; // ETH
 const dest = "0xdd974D5C2e2928deA5F71b9825b8b646686BD200"; // KNC
 const srcAmount = new web3.utils.BN("3000000000000000000000");
 result = await KyberNetwork.methods.findBestRate(src, dest, srcAmount).call();
@@ -373,7 +373,7 @@ Web3 Example:
 // should always do your own testing. If you have questions, visit our
 // https://t.me/KyberDeveloper.
 
-const src = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"; // ETH
+const src = "0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"; // ETH
 const dest = "0xdd974D5C2e2928deA5F71b9825b8b646686BD200"; // KNC
 const srcAmount = new web3.utils.BN("3000000000000000000000");
 result = await KyberNetwork.methods
@@ -437,7 +437,7 @@ Web3 Example:
 // should always do your own testing. If you have questions, visit our
 // https://t.me/KyberDeveloper.
 
-const src = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' // ETH
+const src = '0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' // ETH
 const dest = '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359' // DAI
 const srcQty = new web3.utils.BN('3000000000000000000000')
 
@@ -486,7 +486,7 @@ Web3 Example:
 // should always do your own testing. If you have questions, visit our
 // https://t.me/KyberDeveloper.
 
-const src = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"; // ETH
+const src = "0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"; // ETH
 const dest = "0xdd974D5C2e2928deA5F71b9825b8b646686BD200"; // KNC
 const srcQty = new web3.utils.BN("3000000000000000000000");
 
@@ -767,7 +767,7 @@ Web3 Example:
 // should always do your own testing. If you have questions, visit our
 // https://t.me/KyberDeveloper.
 
-src = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"; // ETH
+src = "0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"; // ETH
 dest = "0xdd974D5C2e2928deA5F71b9825b8b646686BD200"; // KNC
 srcAmount = new web3.utils.BN("3000000000000000000000");
 
@@ -1072,7 +1072,7 @@ Web3 Example:
 // should always do your own testing. If you have questions, visit our
 // https://t.me/KyberDeveloper.
 
-const src = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"; // ETH
+const src = "0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"; // ETH
 const srcAmount = new web3.utils.BN("3000000000000000000000");
 const dest = "0xdd974D5C2e2928deA5F71b9825b8b646686BD200"; // KNC
 const destAddress = "RECIPIENT_ADDRESS";

--- a/docs/api_abi-kybernetworkproxy.md
+++ b/docs/api_abi-kybernetworkproxy.md
@@ -194,7 +194,7 @@ Web3 Example:
 // should always do your own testing. If you have questions, visit our
 // https://t.me/KyberDeveloper.
 
-const src = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' // ETH
+const src = '0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' // ETH
 const dest = '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359' // DAI
 const srcQty = new web3.utils.BN('3000000000000000000000')
 
@@ -466,7 +466,7 @@ Web3 Example:
 // should always do your own testing. If you have questions, visit our
 // https://t.me/KyberDeveloper.
 
-const src = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"; // ETH
+const src = "0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"; // ETH
 const srcAmount = new web3.utils.BN("3000000000000000000000");
 const dest = "0xd26114cd6EE289AccF82350c8d8487fedB8A0C07"; // OMG
 const minConversionRate = new web3.utils.BN("55555");
@@ -518,7 +518,7 @@ If you are part of our [fee sharing program](integrations-feesharing.md), this w
 
 #### Other Notes
 
-- Since ETH is not an ERC20 token, we use `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee` as a proxy address to represent it.
+- Since ETH is not an ERC20 token, we use `0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee` as a proxy address to represent it.
 - If `src` is ETH, then you also need to send ether along with your call.
 - If `src` is an ERC20 token, then `token.approve(KYBER_NETWORK_PROXY_ADDRESS, amount)` should be made beforehand.
 - There is a minimum trading value of 1000 wei tokens. Anything fewer is considered as 0.
@@ -532,7 +532,7 @@ Web3 Example:
 // should always do your own testing. If you have questions, visit our
 // https://t.me/KyberDeveloper.
 
-const src = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"; // ETH
+const src = "0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"; // ETH
 const srcAmount = new web3.utils.BN("3000000000000000000000");
 const dest = "0xdd974D5C2e2928deA5F71b9825b8b646686BD200"; // KNC
 const destAddress = "RECIPIENT_ADDRESS";
@@ -606,7 +606,7 @@ By default, permissionless reserves are included for selection for the trade. To
 
 #### Other Notes
 
-- Since ETH is not an ERC20 token, we use `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee` as a proxy address to represent it.
+- Since ETH is not an ERC20 token, we use `0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee` as a proxy address to represent it.
 - If `src` is ETH, then you also need to send ether along with your call.
 - If `src` is an ERC20 token, then `token.approve(KYBER_NETWORK_PROXY_ADDRESS, amount)` should be made beforehand.
 - There is a minimum trading value of 1000 wei tokens. Anything fewer is considered as 0.
@@ -620,7 +620,7 @@ Web3 Example:
 // should always do your own testing. If you have questions, visit our
 // https://t.me/KyberDeveloper.
 
-const src = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"; // ETH
+const src = "0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"; // ETH
 const srcAmount = new web3.utils.BN("3000000000000000000000");
 const dest = "0xdd974D5C2e2928deA5F71b9825b8b646686BD200"; // KNC
 const destAddress = "RECIPIENT_ADDRESS";

--- a/docs/api_abi-kybernetworkproxyinterface.md
+++ b/docs/api_abi-kybernetworkproxyinterface.md
@@ -134,7 +134,7 @@ If you are part of our [fee sharing program](integrations-feesharing.md), this w
 By default, permissionless reserves are included for selection for the trade. To exclude permissionless reserves, parse `PERM` in the `hint` parameter.
 
 #### Other Notes
-* Since ETH is not an ERC20 token, we use `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee` as a proxy address to represent it.
+* Since ETH is not an ERC20 token, we use `0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee` as a proxy address to represent it.
 * If `src` is ETH, then you also need to send ether along with your call.
 * If `src` is an ERC20 token, then `token.approve(KYBER_NETWORK_PROXY_ADDRESS, amount)` should be made beforehand.
 * There is a minimum trading value of 1000 wei tokens. Anything fewer is considered as 0.

--- a/docs/api_abi-kyberreserve.md
+++ b/docs/api_abi-kyberreserve.md
@@ -274,7 +274,7 @@ Web3 Example:
 // should always do your own testing. If you have questions, visit our
 // https://t.me/KyberDeveloper.
 
-const src = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'  // ETH
+const src = '0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'  // ETH
 const dest = '0xdd974D5C2e2928deA5F71b9825b8b646686BD200' // KNC
 const srcQty = new web3.utils.BN('3000000000000000000000')
 const blockNumber = 6015205
@@ -307,7 +307,7 @@ Web3 Example:
 // should always do your own testing. If you have questions, visit our
 // https://t.me/KyberDeveloper.
 
-const src = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'  // ETH
+const src = '0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'  // ETH
 const dest = '0xdd974D5C2e2928deA5F71b9825b8b646686BD200' // KNC
 const srcQty = new web3.utils.BN('3000000000000000000000')
 const rate = new web3.utils.BN('55555')
@@ -340,7 +340,7 @@ Web3 Example:
 // should always do your own testing. If you have questions, visit our
 // https://t.me/KyberDeveloper.
 
-const src = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'  // ETH
+const src = '0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'  // ETH
 const dest = '0xdd974D5C2e2928deA5F71b9825b8b646686BD200' // KNC
 const destQty = new web3.utils.BN('3000000000000000000000')
 const rate = new web3.utils.BN('55555')

--- a/docs/api_abi-kyberreserveinterface.md
+++ b/docs/api_abi-kyberreserveinterface.md
@@ -52,7 +52,7 @@ function __trade__(ERC20 srcToken, uint srcAmount, ERC20 destToken, address dest
 `true` if the trade was successful, otherwise `false` if unsuccessful
 
 **Notes**
-* `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee` is used to represent Ether. We refer to this as `ETHER_ADDRESS` subsequently.
+* `0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee` is used to represent Ether. We refer to this as `ETHER_ADDRESS` subsequently.
 * The implementation of this function should consider all security checks to prevent rate manipulation, and to make sure the trade executes as expected for the taker.
 * To calculate how much `destToken` is required for the trade given `srcAmount` and `conversionRate`, consider using the [`calcDstQty`](api_abi-tokenquantityconversion.md#calcdstqty) function.
 * The `validate` field can be ignored.

--- a/docs/api_abi-orderbookreserve.md
+++ b/docs/api_abi-orderbookreserve.md
@@ -419,7 +419,7 @@ Web3 Example:
 // should always do your own testing. If you have questions, visit our
 // https://t.me/KyberDeveloper.
 
-const src = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'  // ETH
+const src = '0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'  // ETH
 const dest = '0xe41d2489571d322189246dafa5ebde1f4699f498' // ZRX
 const srcQty = new web3.utils.BN('3000000000000000000000')
 const blockNumber = 6015205

--- a/docs/api_abi-restfulapi.md
+++ b/docs/api_abi-restfulapi.md
@@ -46,7 +46,7 @@ Example:
   "error":false,
   "data":[
     {
-      "src_id":"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "src_id":"0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
       "dst_id":"0xdd974D5C2e2928deA5F71b9825b8b646686BD200",
       "src_qty":[
         0.5671077504725898
@@ -56,7 +56,7 @@ Example:
       ]
     },
     {
-      "src_id":"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "src_id":"0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
       "dst_id":"0xd26114cd6EE289AccF82350c8d8487fedB8A0C07",
       "src_qty":[
         0.18035714285714283
@@ -163,9 +163,9 @@ Example:
     {
       "symbol":"ETH",
       "name":"Ethereum",
-      "address":"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "address":"0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
       "decimals":18,
-      "id":"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+      "id":"0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
     },
     {
       "symbol":"WETH",
@@ -224,7 +224,7 @@ Example:
   "data":[
     {
       "symbol":"ETH",
-      "address":"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "address":"0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
       "swapGasLimit":0,
       "approveGasLimit":0
     },
@@ -293,7 +293,7 @@ Example:
       "quote_symbol": "ETH",
       "quote_name": "Ethereum",
       "quote_decimals": 18,
-      "quote_address": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "quote_address": "0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
       "base_symbol": "WETH",
       "base_name": "Wrapped Ether",
       "base_decimals": 18,
@@ -313,7 +313,7 @@ Example:
       "quote_symbol": "ETH",
       "quote_name": "Ethereum",
       "quote_decimals": 18,
-      "quote_address": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "quote_address": "0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
       "base_symbol": "KNC",
       "base_name": "KyberNetwork",
       "base_decimals": 18,
@@ -333,7 +333,7 @@ Example:
       "quote_symbol": "ETH",
       "quote_name": "Ethereum",
       "quote_decimals": 18,
-      "quote_address": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "quote_address": "0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
       "base_symbol": "DAI",
       "base_name": "DAI",
       "base_decimals": 18,
@@ -385,7 +385,7 @@ Example:
   "data":[
     {
       "src_id":"0xdd974D5C2e2928deA5F71b9825b8b646686BD200",
-      "dst_id":"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "dst_id":"0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
       "src_qty":[
         300,
         150
@@ -397,7 +397,7 @@ Example:
     },
     {
       "src_id":"0xd26114cd6EE289AccF82350c8d8487fedB8A0C07",
-      "dst_id":"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "dst_id":"0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
       "src_qty":[
         10.1,
         20.2,
@@ -448,7 +448,7 @@ Example:
 Example:
 
 ```json
-> curl "https://api.kyber.network/trade_data?user_address=0x8fa07f46353a2b17e92645592a94a0fc1ceb783f&src_id=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee&dst_id=0xdd974D5C2e2928deA5F71b9825b8b646686BD200&src_qty=0.0012&min_dst_qty=0.6&gas_price=medium&wallet_id=0x0859A7958E254234FdC1d200b941fFdfCAb02fC1&nonce=200"
+> curl "https://api.kyber.network/trade_data?user_address=0x8fa07f46353a2b17e92645592a94a0fc1ceb783f&src_id=0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee&dst_id=0xdd974D5C2e2928deA5F71b9825b8b646686BD200&src_qty=0.0012&min_dst_qty=0.6&gas_price=medium&wallet_id=0x0859A7958E254234FdC1d200b941fFdfCAb02fC1&nonce=200"
 {
   "error":false,
   "data":[

--- a/docs/api_abi-sanityrates.md
+++ b/docs/api_abi-sanityrates.md
@@ -48,7 +48,7 @@ Web3 Example:
 
 let sanityRate = await SanityRates.methods.getSanityRate(
   "0xdd974D5C2e2928deA5F71b9825b8b646686BD200", //ERC20 src: KNC token
-  "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", //ERC20 dest: ETH
+  "0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", //ERC20 dest: ETH
 ).call()
 ```
 <br />

--- a/docs/environments-kovan.md
+++ b/docs/environments-kovan.md
@@ -35,7 +35,7 @@ Please note that contracts `KyberReserve` and `ConversionRates` below are using 
 
 ## Token Addresses
 ### `ETH (Ether)`
-`0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`
+`0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`
 
 ### `KNC (Kyber Network)`
 `0xad67cB4d63C9da94AcA37fDF2761AaDF780ff4a2`

--- a/docs/environments-mainnet.md
+++ b/docs/environments-mainnet.md
@@ -48,7 +48,7 @@ Read more [here](api_abi-restfulapi.md#currencies)
 
 ## Token Addresses
 ### `ETH (Ether)`
-`0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`
+`0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`
 
 ### `ABT (ArcBlock)`
 `0xb98d4c97425d9908e66e53a6fdf673acca0be986`

--- a/docs/environments-rinkeby.md
+++ b/docs/environments-rinkeby.md
@@ -35,7 +35,7 @@ Please note that contracts `KyberReserve` and `ConversionRates` below are using 
 
 ## Token Addresses
 ### `ETH (Ether)`
-`0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`
+`0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`
 
 ### `KNC (Kyber Network)`
 `0x6FA355a7b6bD2D6bD8b927C489221BFBb6f1D7B2`

--- a/docs/environments-ropsten.md
+++ b/docs/environments-ropsten.md
@@ -36,7 +36,7 @@ Read more [here](api_abi-restfulapi.md#currencies)
 
 ## Token Addresses
 ### `ETH (Ether)`
-`0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`
+`0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`
 
 ### `ADX (AdEx)`
 `0x499990DB50b34687CDaFb2C8DaBaE4E99d6F38A7`

--- a/docs/integrations-restfulapiguide.md
+++ b/docs/integrations-restfulapiguide.md
@@ -488,9 +488,9 @@ await getSupportedTokens()
 		{  
 			"name":"Ethereum",
 			"decimals":18,
-			"address":"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+			"address":"0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
 			"symbol":"ETH",
-			"id":"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+			"id":"0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
     },
   …
   ]

--- a/docs/integrations-web3guide.md
+++ b/docs/integrations-web3guide.md
@@ -74,7 +74,7 @@ Next, we will define the constants that we will be using for this scenario.
 // Token Details
 const SRC_TOKEN = "ETH";
 const DST_TOKEN = "ZIL";
-const SRC_TOKEN_ADDRESS = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+const SRC_TOKEN_ADDRESS = "0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
 const DST_TOKEN_ADDRESS = "0xaD78AFbbE48bA7B670fbC54c65708cbc17450167";
 const SRC_DECIMALS = 18;
 const DST_DECIMALS = 12;
@@ -296,7 +296,7 @@ const web3 = new Web3(new Web3.providers.WebsocketProvider(WS_PROVIDER));
 // Token Details
 const SRC_TOKEN = "ETH";
 const DST_TOKEN = "ZIL";
-const SRC_TOKEN_ADDRESS = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+const SRC_TOKEN_ADDRESS = "0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
 const DST_TOKEN_ADDRESS = "0xaD78AFbbE48bA7B670fbC54c65708cbc17450167";
 const SRC_DECIMALS = 18;
 const DST_DECIMALS = 12;
@@ -478,7 +478,7 @@ Next, we will define the constants that we will be using for this scenario.
 const SRC_TOKEN = "KNC";
 const DST_TOKEN = "ETH";
 const SRC_TOKEN_ADDRESS = "0x4E470dc7321E84CA96FcAEDD0C8aBCebbAEB68C6";
-const DST_TOKEN_ADDRESS = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+const DST_TOKEN_ADDRESS = "0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
 const SRC_DECIMALS = 18;
 const DST_DECIMALS = 18;
 const MAX_ALLOWANCE = "115792089237316195423570985008687907853269984665640564039457584007913129639935";
@@ -753,7 +753,7 @@ const web3 = new Web3(new Web3.providers.WebsocketProvider(WS_PROVIDER));
 const SRC_TOKEN = "KNC";
 const DST_TOKEN = "ETH";
 const SRC_TOKEN_ADDRESS = "0x4E470dc7321E84CA96FcAEDD0C8aBCebbAEB68C6";
-const DST_TOKEN_ADDRESS = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+const DST_TOKEN_ADDRESS = "0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
 const SRC_DECIMALS = 18;
 const DST_DECIMALS = 18;
 const MAX_ALLOWANCE = "115792089237316195423570985008687907853269984665640564039457584007913129639935";

--- a/docs/reserves-orderbookreserve.md
+++ b/docs/reserves-orderbookreserve.md
@@ -164,7 +164,7 @@ Execute the [`submitTokenToEthOrder(srcAmount, dstAmount)`](api_abi-orderbookres
 The public variables below are used to view available funds for withdrawal or for creating new orders.
 
 **Viewing Unused Ether**<br />
-`makerFunds(makerAddress, 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee)`
+`makerFunds(makerAddress, 0x00eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee)`
 
 **Viewing Unused KNC Tokens**<br />
 `makerUnlockedKnc(makerAddress)`


### PR DESCRIPTION
In the docs the address is missing two zeroes.

You can see it by checking the verified code here: https://ropsten.etherscan.io/address/0x818e6fecd516ecc3849daf6845e3ec868087b755#code